### PR TITLE
Alignment logic pier side changes plus more.

### DIFF
--- a/GS.Server/Alignment/AlignmentV.xaml
+++ b/GS.Server/Alignment/AlignmentV.xaml
@@ -85,7 +85,7 @@
                         </Style>
                     </DataGrid.Resources>
                     <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MaterialDesignDataGridRow}">
+                        <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MaterialDesignDataGridRow}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Selected}" Value="true">
                                     <Setter Property="FontWeight" Value="ExtraBold"></Setter>
@@ -96,12 +96,23 @@
                             </Style.Triggers>
                         </Style>
                     </DataGrid.RowStyle>
+                    <DataGrid.CellStyle>
+                        <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource MaterialDesignDataGridCell}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedForGoto}" Value="true">
+                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentBrush}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGrid.CellStyle>
+
                     <DataGrid.Columns>
                         <!-- Ordinal formatting left in for reference -->
                         <!--<DataGridTemplateColumn Header="#" CellTemplate="{StaticResource OrdinalColumnDataTemplate}" HeaderStyle="{StaticResource RightAlignedGridHeaderStyle}" IsReadOnly="True"/>-->
                         <DataGridTextColumn Header="###" Binding="{Binding Id, StringFormat='{}{0:D3}'}"  HeaderStyle="{StaticResource RightAlignedGridHeaderStyle}" IsReadOnly="True"/>
                         <DataGridTextColumn Header="Altitude" Binding="{Binding AltAz[0], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
                         <DataGridTextColumn Header="Azimuth" Binding="{Binding AltAz[1], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
+                        <DataGridTextColumn Header="Pier Side" Binding="{Binding PierSide}" IsReadOnly="True" />
                         <DataGridTextColumn Header="Mount RA/Dec Axes" Binding="{Binding MountAxes}" IsReadOnly="True" />
                         <DataGridTextColumn Header="Observed RA/Dec Axis" Binding="{Binding ObservedAxes}" IsReadOnly="True" />
                         <DataGridTextColumn Header="Correction" Binding="{Binding Correction}" IsReadOnly="True" />

--- a/NStarAlignment/DataTypes/AlignmentPoint.cs
+++ b/NStarAlignment/DataTypes/AlignmentPoint.cs
@@ -20,13 +20,18 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using NStarAlignment.Utilities;
 
 namespace NStarAlignment.DataTypes
 {
+    [TypeConverter(typeof(EnumTypeConverter))]
     public enum PierSide
     {
+        [Description("East")]
         EastLookingWest,
+        [Description("West")]
         WestLookingEast,
+        [Description("Unknown")]
         Unknown
     }
 
@@ -72,6 +77,10 @@ namespace NStarAlignment.DataTypes
 
         private bool _selected;
 
+        /// <summary>
+        /// Selected for correcting display
+        /// </summary>
+        [JsonIgnore]
         public bool Selected
         {
             get => _selected;
@@ -79,6 +88,23 @@ namespace NStarAlignment.DataTypes
             {
                 if (value == _selected) return;
                 _selected = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private bool _selectedForGoto;
+
+        /// <summary>
+        /// Selected for slew/goto calculation
+        /// </summary>
+        [JsonIgnore]
+        public bool SelectedForGoto
+        {
+            get => _selectedForGoto;
+            set
+            {
+                if (value == _selectedForGoto) return;
+                _selectedForGoto = value;
                 OnPropertyChanged();
             }
         }

--- a/NStarAlignment/NStarAlignment.csproj
+++ b/NStarAlignment/NStarAlignment.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Utilities\AstroConvert.cs" />
     <Compile Include="Model\AlignmentModel.cs" />
     <Compile Include="DataTypes\Matrix.cs" />
+    <Compile Include="Utilities\EnumTypeConverter.cs" />
     <Compile Include="Utilities\Range.cs" />
     <Compile Include="DataTypes\Angle.cs" />
     <Compile Include="DataTypes\AxisPosition.cs" />

--- a/NStarAlignment/Utilities/EnumTypeConverter.cs
+++ b/NStarAlignment/Utilities/EnumTypeConverter.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+
+namespace NStarAlignment.Utilities
+{
+    public class EnumTypeConverter : EnumConverter
+    {
+        private Type m_EnumType;
+        public EnumTypeConverter(Type type)
+            : base(type)
+        {
+            m_EnumType = type;
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destType)
+        {
+            return destType == typeof(string);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destType)
+        {
+            DescriptionAttribute dna = null;
+            if (value != null)
+            {
+                FieldInfo fi = m_EnumType.GetField(Enum.GetName(m_EnumType, value));
+                dna =
+                    (DescriptionAttribute)Attribute.GetCustomAttribute(
+                        fi, typeof(DescriptionAttribute));
+            }
+            if (dna != null)
+                return dna.Description;
+            else
+                return (value != null ? value.ToString() : "");
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type srcType)
+        {
+            return srcType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            foreach (FieldInfo fi in m_EnumType.GetFields())
+            {
+                DescriptionAttribute dna =
+                    (DescriptionAttribute)Attribute.GetCustomAttribute(
+                        fi, typeof(DescriptionAttribute));
+
+                if ((dna != null) && ((string)value == dna.Description))
+                    return Enum.Parse(m_EnumType, fi.Name);
+            }
+            return Enum.Parse(m_EnumType, (string)value ?? string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
In the alignment logic the fallback selection of the nearest point now filters on Pier Side rather than selecting across the whole sky.

Fixed a bug in the information logging when no point is found for determining the mount axis position.
Updated the alignment point display to include a column for the pier side at the time the point was created.
Updated the alignment point display to show the points used when determing a slew target position using the current schemes accent color.